### PR TITLE
feat: increase watchlist limit from 10 to 15

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2182,10 +2182,10 @@ server.register(async (instance) => {
 
         if (!githubUsername) return reply.status(400).send({ message: 'githubUsername is required' });
 
-        // Check limit (max 10 per user)
+        // Check limit (max 15 per user)
         const existing = await db.select().from(schema.watchlist).where(eq(schema.watchlist.userId, userId));
-        if (existing.length >= 10) {
-            return reply.status(400).send({ message: 'Watchlist is full (max 10). Remove someone first.' });
+        if (existing.length >= 15) {
+            return reply.status(400).send({ message: 'Watchlist is full (max 15). Remove someone first.' });
         }
 
         // Verify the GitHub user exists & fetch their public profile

--- a/src/components/EyeSection.tsx
+++ b/src/components/EyeSection.tsx
@@ -243,7 +243,7 @@ function ManageWatchlistSheet({ watchlist, onAdd, onRemove, adding, authToken, o
               </Button>
             )}
 
-            <p className="text-xs text-muted-foreground">{watchlist.length}/10 slots used</p>
+            <p className="text-xs text-muted-foreground">{watchlist.length}/15 slots used</p>
 
             {/* Current watchlist */}
             <div className="space-y-2">
@@ -453,7 +453,7 @@ export function EyeSection({
       {/* Header row — centered on mobile */}
       <div className="flex flex-col items-center sm:flex-row sm:items-center sm:justify-between gap-3 flex-wrap">
         <p className="text-sm text-muted-foreground order-2 sm:order-1">
-          Track competitors' public activity · {watchlist.length}/10 slots
+          Track competitors' public activity · {watchlist.length}/15 slots
         </p>
         <div className="flex gap-2 order-1 sm:order-2">
           <ManageWatchlistSheet

--- a/src/pages/TheEye.tsx
+++ b/src/pages/TheEye.tsx
@@ -409,7 +409,7 @@ export default function TheEye() {
           </div>
 
           <p className="text-xs text-muted-foreground mt-2 ml-1">
-            Watchlist: {watchlist.length}/10 · Only public GitHub activity is tracked
+            Watchlist: {watchlist.length}/15 · Only public GitHub activity is tracked
           </p>
         </section>
 


### PR DESCRIPTION
This PR increases the maximum watchlist limit from 10 to 15, updating both the server check and the frontend UI elements/labels.